### PR TITLE
Gdt 317 return to search

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ gunicorn = "*"
 python3-saml = "*"
 lxml = "*"
 pyjwt = "*"
+werkzeug = "3.0.2"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4c3ad7def1a04877b142f808672e7b8faffcc75bbc2df3cb26e6c7c7812fad2d"
+            "sha256": "52e0a20d38eb4cabdb85682728225144266704aa23a57e65dc42f7ad9c77fb7c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -320,11 +320,12 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18",
-                "sha256:fc9645dc43e03e4d630d23143a04a7f947a9a3b5727cd535fdfe155a17cc48c8"
+                "sha256:3aac3f5da756f93030740bc235d3e09449efcf65f2f55e3602e1d851b8f48795",
+                "sha256:e39b645a6ac92822588e7b39a692e7828724ceae0b0d702ef96701f90e70128d"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==3.0.3"
+            "version": "==3.0.2"
         },
         "xmlsec": {
             "hashes": [

--- a/cdnauth/cdn.py
+++ b/cdnauth/cdn.py
@@ -37,8 +37,10 @@ def session_jwt():
             timdexui = False
 
         response = make_response(
-            render_template("download.html", cdn_resource=cdn_resource,
-                            timdexui=timdexui))
+            render_template(
+                "download.html", cdn_resource=cdn_resource, timdexui=timdexui
+            )
+        )
         token = jwt.encode(
             {
                 "user": session["samlNameId"],

--- a/cdnauth/cdn.py
+++ b/cdnauth/cdn.py
@@ -28,9 +28,17 @@ def session_jwt():
         if valid_redirect(request.args["cdn_resource"]) is False:
             logging.info(f"Invalid redirect URL: {request.args['cdn_resource']}")
             return "Invalid redirect URL"
+
+        cdn_resource = request.args["cdn_resource"]
+
+        if "timdexui=true" in cdn_resource:
+            timdexui = True
+        else:
+            timdexui = False
+
         response = make_response(
-            render_template("download.html", cdn_resource=request.args["cdn_resource"])
-        )
+            render_template("download.html", cdn_resource=cdn_resource,
+                            timdexui=timdexui))
         token = jwt.encode(
             {
                 "user": session["samlNameId"],

--- a/cdnauth/templates/download.html
+++ b/cdnauth/templates/download.html
@@ -3,13 +3,16 @@
   <head>
     <!--Inform web browser to redirect user to another location
     See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta for more information -->
-    <meta http-equiv="refresh" content="5; url={{ cdn_resource }}" />
+    <meta http-equiv="refresh" content="3; url={{ cdn_resource }}" />
   </head>
   <body>
-    <p>Authenticated successfully</p>
-    <p>
-      Your download should start shortly. If it does not, this is a link to your
-      <a href="{{ cdn_resource }}">requested file</a>.
-    </p>
+    <p>MIT authentication successful: your download should start shortly.</p>
+    <p>If it does not, <a href="{{ cdn_resource }}">use this link to access the file</a>.</p>
+
+    <!-- only display the close button if the user came from TIMDEX-UI where we know this is correct -->
+
+    {% if timdexui == True %}
+    <p>Close this window/tab to return to your search.</p>
+    {% endif %}
   </body>
 </html>

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -57,8 +57,20 @@ def test_valid_download_url_with_session(client):
 
     res = client.get("/?cdn_resource=http://cdn.libraries.mit.edu/restricted/stuff.zip")
     assert res.status_code == 200
-    assert b"Authenticated successfully" in res.data
-    assert b"Your download should start shortly" in res.data
+    assert b"MIT authentication successful: " in res.data
+    assert b"your download should start shortly." in res.data
+    assert b"Close this window/tab to return to your search." not in res.data
+
+
+def test_valid_download_url_with_session_timdexui_flag(client):
+    with client.session_transaction() as session:
+        session["samlNameId"] = "yo@example.com"
+
+    res = client.get("/?cdn_resource=http://cdn.libraries.mit.edu/restricted/stuff.zip?timdexui=true")
+    assert res.status_code == 200
+    assert b"MIT authentication successful: " in res.data
+    assert b"your download should start shortly." in res.data
+    assert b"Close this window/tab to return to your search." in res.data
 
 
 def test_valid_request_sets_cookie(client):

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -66,7 +66,9 @@ def test_valid_download_url_with_session_timdexui_flag(client):
     with client.session_transaction() as session:
         session["samlNameId"] = "yo@example.com"
 
-    res = client.get("/?cdn_resource=http://cdn.libraries.mit.edu/restricted/stuff.zip?timdexui=true")
+    res = client.get(
+        "/?cdn_resource=http://cdn.libraries.mit.edu/restricted/stuff.zip?timdexui=true"
+    )
     assert res.status_code == 200
     assert b"MIT authentication successful: " in res.data
     assert b"your download should start shortly." in res.data


### PR DESCRIPTION
NOTE: this is deployed to our staging environment if you'd like to confirm how it works in a deployed state.


### Why these changes are being introduced

A sentence or two explaining why these changes are here.
Why are these changes being introduced:

* Improved wording
* Detect when coming from TIMDEX-UI and display message to close window
  to return to search

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/GDT-317
* https://mitlibraries.atlassian.net/browse/GDT-304

How does this address that need:

* Updates words and adds condition if `timdexui=true` is found within
  the `cdn_resource` URL parameter

Document any side effects to this change:

* Also descreased auto-download time to 3 seconds from 5.
* Pin Werkzeug version as next version causes local bug (or is bugged upstream... not sure which yet)
